### PR TITLE
Don't delete matching params

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function normalizeQueryParams(params) {
       var index = lowerCased.indexOf(key.toLowerCase());
       if (index > -1) {
         req.query[params[index]] = req.query[key];
-        delete req.query[key];
+        if (key !== params[index]) delete req.query[key];
       }
     });
     next();

--- a/test.js
+++ b/test.js
@@ -7,7 +7,8 @@ describe('normalize query params', function() {
   beforeEach(function() {
     req = {
       query: {
-        someparam: 5
+        someparam: 5,
+        alreadyCorrectParam: 42
       }
     };
   });
@@ -15,6 +16,13 @@ describe('normalize query params', function() {
   it('should normalize configured params', function(done) {
     normalizeQueryParams(['someParam'])(req, null, function() {
       expect(req.query.someParam).to.equal(5);
+      done();
+    });
+  });
+
+  it('should not remove configured params that are passed correctly', function(done) {
+    normalizeQueryParams(['alreadyCorrectParam'])(req, null, function() {
+      expect(req.query.alreadyCorrectParam).to.equal(42);
       done();
     });
   });


### PR DESCRIPTION
Delete the query parameters from the request only if they do not already match the intended casing.
